### PR TITLE
change to objectexplorer menu context filter

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
             "objectExplorer/item/context": [
                 {
                     "command": "extension.sayHello",
-                    "when": "connectionProvider == MSSQL  && !treeNode",
+                    "when": "connectionProvider == MSSQL && nodeType && nodeType == Server",
                     "group": "1mysection1"
                 }
             ]


### PR DESCRIPTION
This corrects the issue - the object explorer menu didn't appear as expected

The previous example wasn't working on the current ADS (1.3.7-insider), updated has been tested and is seen in https://github.com/Microsoft/azuredatastudio/blob/master/extensions/profiler/package.json